### PR TITLE
sta: add REGULATORY_DISABLE_BEACON_HINTS

### DIFF
--- a/main.c
+++ b/main.c
@@ -415,6 +415,7 @@ int wfx_probe(struct wfx_dev *wdev)
 	}
 
 	if (wdev->hw_caps.region_sel_mode) {
+		wdev->hw->wiphy->regulatory_flags |= REGULATORY_DISABLE_BEACON_HINTS;
 		wdev->hw->wiphy->bands[NL80211_BAND_2GHZ]->channels[11].flags |= IEEE80211_CHAN_NO_IR;
 		wdev->hw->wiphy->bands[NL80211_BAND_2GHZ]->channels[12].flags |= IEEE80211_CHAN_NO_IR;
 		wdev->hw->wiphy->bands[NL80211_BAND_2GHZ]->channels[13].flags |= IEEE80211_CHAN_DISABLED;


### PR DESCRIPTION
the beacon hint procedure was removing the flag IEEE80211_CHAN_NO_IR
from channels where a bss is discovered. This was making subsequent
scans to fail because the driver was trying active scans on
prohibited channels